### PR TITLE
Base definitions for online estimators

### DIFF
--- a/asoh/estimators/__init__.py
+++ b/asoh/estimators/__init__.py
@@ -1,0 +1,1 @@
+""" Collection of state estimators """

--- a/asoh/estimators/online/__init__.py
+++ b/asoh/estimators/online/__init__.py
@@ -1,0 +1,1 @@
+""" Collection of online estimators """

--- a/asoh/estimators/online/base.py
+++ b/asoh/estimators/online/base.py
@@ -1,0 +1,80 @@
+"""
+Base classes to facilitate  definition of online estimators and hidden states, as well as to establish interfaces
+between online estimators and models, transient states, and A-SOH parameters.
+"""
+from abc import abstractmethod
+
+import numpy as np
+from pydantic import BaseModel
+
+from asoh.models.base import CellModel
+
+
+class MultivariateRandomVariable(BaseModel, arbitrary_types_allowed=True):
+    """
+    Base class to help represent a multivariate random variable
+    """
+
+    @property
+    @abstractmethod
+    def mean(self) -> np.ndarray:
+        """
+        Provides mean of distribution
+        """
+        pass
+
+
+class HiddenState(MultivariateRandomVariable):
+    """
+    Defines the hidden state that is updated by the online estimator.
+    """
+    pass
+
+
+class OutputMeasurements(MultivariateRandomVariable):
+    """
+    Defines a container for the outputs
+    """
+    pass
+
+
+class ModelFilterInterface():
+    """
+    Defines the interface between the cell model and the online estimators. Communication between these is established
+    through the use of numpy.ndarray objects.
+
+    Args:
+        cell_model: CellModel object that knows how to update transient states from A-SOH and inputs, and knows how to
+            calculate outputs from A-SOH, inputs, and transient state
+    """
+
+    cell_model: CellModel
+
+    def __init__(self, cell_model: CellModel):
+        self.cell_model = cell_model
+
+    @abstractmethod
+    def update_hidden_states(self, hidden_state: HiddenState) -> HiddenState:
+        """
+        Function that updates the hidden state.
+
+        Args:
+            hidden_state: current hidden state of the system
+
+        Returns:
+            new_hidden: updated hidden state
+        """
+        pass
+
+    @abstractmethod
+    def predict_measurement(self, hidden_state: HiddenState) -> OutputMeasurements:
+        """
+        Function to predict measurement from the hidden state
+
+        Args:
+            hidden_state: current hidden state of the system
+
+        Returns:
+            pred_measurement: predicted measurement
+        """
+        pass

--- a/asoh/models/base.py
+++ b/asoh/models/base.py
@@ -384,7 +384,7 @@ class InputQuantities(GeneralContainer):
     current: float = Field(description='Current applied to the storage system. Units: A')
 
 
-class OutputMeasurements(GeneralContainer):
+class OutputQuantities(GeneralContainer):
     """Output for observables from a battery system
 
     Add new fields to subclasses of ``ControlState`` for more complex systems
@@ -432,7 +432,7 @@ class CellModel():
             input: InputQuantities,
             transient_state: TransientVector,
             asoh: AdvancedStateOfHealth,
-            *args, **kwargs) -> OutputMeasurements:
+            *args, **kwargs) -> OutputQuantities:
         """
         Compute expected output (terminal voltage, etc.) of the model.
         """

--- a/asoh/models/base.py
+++ b/asoh/models/base.py
@@ -394,7 +394,7 @@ class OutputMeasurements(GeneralContainer):
         Field(description='Voltage output of a battery cell/model. Units: V')
 
 
-class HiddenVector(GeneralContainer):
+class TransientVector(GeneralContainer):
     """
     Stores physical transient/instantenous hidden state
     """
@@ -421,16 +421,16 @@ class CellModel():
     def update_transient_state(
             self,
             input: InputQuantities,
-            transient_state: HiddenVector,
+            transient_state: TransientVector,
             asoh: AdvancedStateOfHealth,
-            *args, **kwargs) -> HiddenVector:
+            *args, **kwargs) -> TransientVector:
         pass
 
     @abstractmethod
     def calculate_terminal_voltage(
             self,
             input: InputQuantities,
-            transient_state: HiddenVector,
+            transient_state: TransientVector,
             asoh: AdvancedStateOfHealth,
             *args, **kwargs) -> OutputMeasurements:
         """

--- a/asoh/models/ecm/ins_outs.py
+++ b/asoh/models/ecm/ins_outs.py
@@ -1,5 +1,5 @@
 from pydantic import Field
-from asoh.models.base import InputQuantities, OutputMeasurements
+from asoh.models.base import InputQuantities, OutputQuantities
 
 
 class ECMInput(InputQuantities):
@@ -12,7 +12,7 @@ class ECMInput(InputQuantities):
 
 # TODO (vventuri): Remember we need to implement ways to denoise SOC, Qt, R0,
 #                   which require more outputs
-class ECMMeasurement(OutputMeasurements):
+class ECMMeasurement(OutputQuantities):
     """
     Controls the outputs of the ECM.
     """

--- a/asoh/models/ecm/transient.py
+++ b/asoh/models/ecm/transient.py
@@ -4,10 +4,10 @@ from numbers import Number
 from pydantic import Field
 import numpy as np
 
-from asoh.models.base import HiddenVector
+from asoh.models.base import TransientVector
 
 
-class ECMTransientVector(HiddenVector,
+class ECMTransientVector(TransientVector,
                          validate_assignment=True):
     """Description of the state of charge of an ECM and all components"""
 


### PR DESCRIPTION
Here, we have base definitions for online estimators. The main idea is that the estimators should be fully numeric, and totally agnostic to the models being used (though they must know what numbers/`numpy.ndarray`s are inputs, hidden states, and outputs, of course).

 We have a `MultivariateRandomVariable` class, which is used to describe hidden states and measurements (maybe also inputs, but I don't know how to properly do that yet). We also establish a class to facilitate the interface between `CellModel`s and the estimators. 