### PR TITLE
All ECM components initialized fully frozen

### DIFF
--- a/asoh/models/ecm/components.py
+++ b/asoh/models/ecm/components.py
@@ -12,7 +12,6 @@ class MaxTheoreticalCapacity(HealthVariable):
     """Defines maximum theoretical discharge capacity of a cell"""
     base_values: float = \
         Field(description='Maximum theoretical discharge capacity of a cell. Units: Amp-hour')
-    updatable: set[str] = Field(default_factory=lambda: {'base_values'})
 
     @property
     def value(self) -> float:
@@ -78,9 +77,6 @@ class RCComponent(HealthVariable):
     """
     r: Resistance = Field(description='Resistive element of RC component')
     c: Capacitance = Field(description='Capacitive element of RC component')
-    updatable: set[str] = \
-        Field(default_factory=lambda: {'r', 'c'},
-              description='Define updatable parameters (if any)')
 
     @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
     def get_value(self,
@@ -156,6 +152,3 @@ class HysteresisParameters(SOCInterpolatedHealth):
     gamma: float = Field(default=0.,
                          description='Exponential approach rate. Units: 1/V',
                          ge=0.)
-    updatable: set[str] = \
-        Field(default_factory=lambda: {'base_values', 'gamma'},
-              description='Define updatable parameters (if any)')

--- a/asoh/models/ecm/utils.py
+++ b/asoh/models/ecm/utils.py
@@ -19,7 +19,6 @@ class SOCInterpolatedHealth(HealthVariable, validate_assignment=True):
         Literal['linear', 'nearest', 'nearest-up', 'zero', 'slinear',
                 'quadratic', 'cubic', 'previous', 'next'] = \
         Field(default='linear', description='Type of interpolation to perform')
-    updatable: set[str] = Field(default_factory=lambda: {'base_values'})
 
     # Let us cache the interpolation function so we don't have to re-do it every
     # time we want to get a value


### PR DESCRIPTION
Previously, some of the ECM components (such as the RCComponent) were being initialized with some inner fields updatable by default. This can cause issues, as the base HealthVariable class assumes everything is frozen unless the user says otherwise. Therefore, it made sense to maintain the updatable field empty for all HealthVariable children.

Fixes #31 