### PR TITLE
Fix ECM broadcasting issues

### DIFF
--- a/moirae/models/ecm/__init__.py
+++ b/moirae/models/ecm/__init__.py
@@ -97,7 +97,7 @@ class EquivalentCircuitModel(CellModel):
         # We need to figure out if the current changes sign during this process
 
         if current_k * current_kp1 >= 0 or self.current_behavior == 'constant':
-            hyst_kp1 = hysteresis_solver_const_sign(h0=transient_state.hyst.copy(),
+            hyst_kp1 = hysteresis_solver_const_sign(h0=transient_state.hyst,
                                                     M=M,
                                                     kappa=kappa,
                                                     dt=delta_t,
@@ -107,7 +107,7 @@ class EquivalentCircuitModel(CellModel):
         else:
             # solving for time until current == 0
             phi = -current_k / current_slope
-            h_mid = hysteresis_solver_const_sign(h0=transient_state.hyst.copy(),
+            h_mid = hysteresis_solver_const_sign(h0=transient_state.hyst,
                                                  M=M,
                                                  kappa=kappa,
                                                  dt=phi,
@@ -151,7 +151,7 @@ class EquivalentCircuitModel(CellModel):
 
         # Check series capacitance
         if transient_state.q0 is not None:
-            Vt = Vt + transient_state.q0.copy() / asoh.c0.get_value(soc=transient_state.soc.copy())
+            Vt = Vt + transient_state.q0 / asoh.c0.get_value(soc=transient_state.soc.copy())
 
         # Check RC elements
         if transient_state.i_rc.shape[-1] > 0:

--- a/moirae/models/ecm/utils.py
+++ b/moirae/models/ecm/utils.py
@@ -61,6 +61,8 @@ class SOCInterpolatedHealth(HealthVariable):
             y = self.base_values[:, 0]
             if soc_batch_size > 0 and batch_size == 1:
                 return np.repeat(y, soc.size, axis=0).reshape(input_dims)
+            elif soc_batch_size == 1 and batch_size > 1:
+                return y.reshape((batch_size,) + input_dims)
             return y.reshape(input_dims)
 
         # Run the interpolator, but the results mean something different
@@ -132,5 +134,5 @@ def hysteresis_solver_const_sign(
         exp_factor = -exp_factor
     exp_factor = np.exp(exp_factor)
     h_dt = exp_factor * h0
-    h_dt += (1 - exp_factor) * M
+    h_dt = h_dt + ((1 - exp_factor) * M)
     return h_dt

--- a/tests/models/ecm/test_batch.py
+++ b/tests/models/ecm/test_batch.py
@@ -149,7 +149,9 @@ def test_broadcasting(rint):
                                            asoh=asoh)
     volt = ecm.calculate_terminal_voltage(new_inputs=input1, transient_state=transient, asoh=asoh)
     assert new_trans.batch_size == 1
+    assert new_trans.to_numpy().shape[1] == 2
     assert volt.batch_size == 1
+    assert volt.to_numpy().shape[1] == 1
     # Trans: batched; ASOH: unbatched
     new_trans = ecm.update_transient_state(previous_inputs=input0,
                                            new_inputs=input1,
@@ -157,7 +159,9 @@ def test_broadcasting(rint):
                                            asoh=asoh)
     volt = ecm.calculate_terminal_voltage(new_inputs=input1, transient_state=trans_batch, asoh=asoh)
     assert new_trans.batch_size == batch_size
+    assert new_trans.to_numpy().shape[1] == 2
     assert volt.batch_size == batch_size
+    assert volt.to_numpy().shape[1] == 1
     # Trans: unbatched; ASOH: batched
     new_trans = ecm.update_transient_state(previous_inputs=input0,
                                            new_inputs=input1,
@@ -165,7 +169,9 @@ def test_broadcasting(rint):
                                            asoh=asoh_batch)
     volt = ecm.calculate_terminal_voltage(new_inputs=input1, transient_state=transient, asoh=asoh_batch)
     assert new_trans.batch_size == batch_size
+    assert new_trans.to_numpy().shape[1] == 2
     assert volt.batch_size == batch_size
+    assert volt.to_numpy().shape[1] == 1
     # Trans: batched; ASOH: batched
     new_trans = ecm.update_transient_state(previous_inputs=input0,
                                            new_inputs=input1,
@@ -173,4 +179,6 @@ def test_broadcasting(rint):
                                            asoh=asoh_batch)
     volt = ecm.calculate_terminal_voltage(new_inputs=input1, transient_state=trans_batch, asoh=asoh_batch)
     assert new_trans.batch_size == batch_size
+    assert new_trans.to_numpy().shape[1] == 2
     assert volt.batch_size == batch_size
+    assert volt.to_numpy().shape[1] == 1


### PR DESCRIPTION
This fixes #65. 

ECM can now properly broadcast regardless of whether transient vector and A-SOH are batched. That is, the model works when:

- Transient vector and A-SOH are both un-batched
- One is batched and the other is not (2 cases) 
- Both are batched (with equal batch_size)

Also provides more complete batch tests to account for these 4 cases.