### PR TITLE
Correct sign convention when converting to batdata format

### DIFF
--- a/docs/system-models.rst
+++ b/docs/system-models.rst
@@ -45,8 +45,8 @@ necessary to specify a particular storage systems.
 
 .. note::
 
-    Moirae's models assume that a positive current for batteries charging,
-    which is opposite from the `battery-data-toolkit's choice <https://rovi-org.github.io/battery-data-toolkit/schemas.html>`_,
+    Moirae's models assume that a positive current corresponds to charging a battery,
+    opposite from the `battery-data-toolkit's choice <https://rovi-org.github.io/battery-data-toolkit/schemas.html>`_,
     but in line with conventions common for battery modeling.
 
 

--- a/docs/system-models.rst
+++ b/docs/system-models.rst
@@ -43,6 +43,12 @@ necessary to specify a particular storage systems.
     The ``InputQuantities`` and ``OutputQuantities`` classes define
     the required names for the time, current, and voltage.
 
+.. note::
+
+    Moirae's models assume that a positive current for batteries charging,
+    which is opposite from the `battery-data-toolkit's choice <https://rovi-org.github.io/battery-data-toolkit/schemas.html>`_,
+    but in line with conventions common for battery modeling.
+
 
 Health Parameters
 -----------------

--- a/moirae/estimators/online/filters/conversions.py
+++ b/moirae/estimators/online/filters/conversions.py
@@ -194,7 +194,7 @@ class FirstOrderTaylorConversionOperator(ConversionOperator):
     the covariance of the transformed vector :math:`f` can be simply expressed as
     :math:`{\\Sigma}_f = J {\\Sigma}_X J^T`, exactly like that in the
     :class:`~moirae.estimators.online.filters.conversions.LinearConversionOperator`
-    Full explanation on `Wikipedia <https://en.wikipedia.org/wiki/Propagation_of_uncertainty#Non-linear_combinations>`
+    Full explanation on `Wikipedia <https://en.wikipedia.org/wiki/Propagation_of_uncertainty#Non-linear_combinations>`_.
     """
     @abstractmethod
     def get_jacobian(self, pivot: np.ndarray) -> np.ndarray:

--- a/moirae/simulator.py
+++ b/moirae/simulator.py
@@ -174,6 +174,7 @@ class Simulator:
         output = []
         for _, group in df.groupby('batch'):
             batch = BatteryDataset(raw_data=group.drop(columns=['batch']))
+            batch.raw_data['current'] *= -1  # Moirae uses the opposite sign convention as batdata
 
             # Compile names for the other columns
             #  TODO (wardlt): I bet I can grab the description from the model fields.


### PR DESCRIPTION
The sign convention is different, and I missed a conversion. 

Also caught a batching error then clarified the point in the documentation.

Closes #43 . I'm comfortable with them being different.