### PR TITLE
Update to use new version of battdat

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
         with:
-          python-version: 3.9  # Sphinx 8 requires 3.10, so we'll have to change this eventually
+          python-version: '3.10'
       - name: Install Pandoc
         run: |
           sudo apt update

--- a/dev/environment.yml
+++ b/dev/environment.yml
@@ -3,7 +3,7 @@ channels:
   - defaults
   - conda-forge
 dependencies:
-  - python==3.9.*
+  - python==3.10.*
 
   # Basics
   - tqdm

--- a/docs/system-models.rst
+++ b/docs/system-models.rst
@@ -44,13 +44,6 @@ necessary to specify a particular storage systems.
     The ``InputQuantities`` and ``OutputQuantities`` classes define
     the required names for the time, current, and voltage.
 
-.. note::
-
-    Moirae's models assume that a positive current corresponds to charging a battery,
-    opposite from the `battery-data-toolkit's choice <https://rovi-org.github.io/battery-data-toolkit/schemas.html>`_,
-    but in line with conventions common for battery modeling.
-
-
 Health Parameters
 -----------------
 

--- a/moirae/estimators/offline/loss.py
+++ b/moirae/estimators/offline/loss.py
@@ -1,7 +1,7 @@
 """Interfaces that evaluate the fitness of a set of battery state parameters
 provided as a NumPy array."""
 import numpy as np
-from batdata.data import BatteryDataset
+from battdat.data import BatteryDataset
 
 from moirae.interface import row_to_inputs
 from moirae.models.base import CellModel, HealthVariable, GeneralContainer
@@ -76,7 +76,8 @@ class MeanSquaredLoss(BaseLoss):
         asoh_x = self.asoh.make_copy(x[:, n_states:])
 
         # Build a simulator
-        initial_input, initial_output = row_to_inputs(self.observations.raw_data.iloc[0])
+        raw_data = self.observations.datasets['raw_data']
+        initial_input, initial_output = row_to_inputs(raw_data.iloc[0])
         sim = Simulator(
             cell_model=self.cell_model,
             asoh=asoh_x,
@@ -86,8 +87,8 @@ class MeanSquaredLoss(BaseLoss):
 
         # Prepare the output arrays
         num_outs = len(initial_output)
-        pred_y = np.zeros((len(self.observations.raw_data), 1, num_outs))
-        true_y = np.zeros((len(self.observations.raw_data), x.shape[0], num_outs))
+        pred_y = np.zeros((len(raw_data), 1, num_outs))
+        true_y = np.zeros((len(raw_data), x.shape[0], num_outs))
 
         true_y[0, :] = initial_output.to_numpy()
         y = self.cell_model.calculate_terminal_voltage(initial_input, state_x, asoh_x)

--- a/moirae/interface/__init__.py
+++ b/moirae/interface/__init__.py
@@ -10,8 +10,8 @@ import h5py
 import numpy as np
 import pandas as pd
 from tqdm import tqdm
-from batdata.data import BatteryDataset
-from batdata.streaming import iterate_records_from_file
+from battdat.data import BatteryDataset
+from battdat.streaming import iterate_records_from_file
 
 from moirae.estimators.online import OnlineEstimator
 from moirae.interface.hdf5 import HDF5Writer
@@ -37,7 +37,7 @@ def row_to_inputs(row: pd.Series, default_temperature: float = 25) -> Tuple[Inpu
     # TODO (wardlt): Remove hard code from ECM when we're ready (maybe a "from_batdata" to the model class?)
     inputs = ECMInput(
         time=row['test_time'],
-        current=-row['current'],  # Opposite sign convention from batdata
+        current=row['current'],
         temperature=row['temperature'] if use_temp else default_temperature
     )
     outputs = ECMMeasurement(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "moirae"
 version = "0.0.1"
 description = "Algorithms for automatic assessment of advanced state of health for batteries"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = {file = "LICENSE"}
 keywords = ["batteries", "science", "data science"]
 authors = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from typing import Tuple
 
 from pytest import fixture
-from batdata.data import BatteryDataset
+from battdat.data import BatteryDataset, CellDataset
 import pandas as pd
 import numpy as np
 
@@ -45,7 +45,7 @@ def make_dataset(simple_rint):
 
     def _update_outputs(time, current, transient, outputs, cycle_number):
         output['test_time'].append(time)
-        output['current'].append(-current)  # Battery data toolkit uses opposite sign convention
+        output['current'].append(current)
         output['voltage'].append(outputs.terminal_voltage.item())
         output['cycle_number'] = cycle_number
 
@@ -71,7 +71,7 @@ def make_dataset(simple_rint):
         start_time += rest_time
 
     raw_data = pd.DataFrame(dict(output))
-    return BatteryDataset(raw_data=raw_data)
+    return CellDataset(raw_data=raw_data)
 
 
 dataset = None

--- a/tests/estimators/offline/test_scipy.py
+++ b/tests/estimators/offline/test_scipy.py
@@ -10,7 +10,7 @@ def test_scipy(simple_rint, timeseries_dataset, state_only):
     rint_asoh, rint_state, _, ecm_model = simple_rint
 
     # Truncate the battery dataset
-    timeseries_dataset.raw_data = timeseries_dataset.raw_data.head(32)
+    timeseries_dataset.datasets['raw_data'] = timeseries_dataset.datasets['raw_data'].head(32)
 
     # Alter the estimated state slightly
     state_0 = rint_state.make_copy(np.array([[0.05, 0.]]))

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -62,7 +62,7 @@ def test_interface_stream(simple_rint, timeseries_dataset, tmpdir):
     estimator = make_joint_ukf(rint_asoh, rint_transient, rint_inputs)
 
     # Run then make sure it returns the proper data types
-    timeseries_dataset.to_batdata_hdf(h5_path)
+    h5_path = str(Path(tmpdir) / 'example.h5')
     timeseries_dataset.to_hdf(h5_path)
     state_mean, estimator = run_online_estimate(h5_path, estimator, hdf5_output=Path(tmpdir) / 'estimates.h5')
     assert state_mean.shape[0] == len(timeseries_dataset.raw_data)

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -63,7 +63,7 @@ def test_interface_stream(simple_rint, timeseries_dataset, tmpdir):
 
     # Run then make sure it returns the proper data types
     h5_path = Path(tmpdir) / 'example.h5'
-    timeseries_dataset.to_batdata_hdf(h5_path)
+    timeseries_dataset.to_hdf(h5_path)
     state_mean, estimator = run_online_estimate(h5_path, estimator, hdf5_output=Path(tmpdir) / 'estimates.h5')
     assert state_mean.shape[0] == len(timeseries_dataset.raw_data)
 

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -40,7 +40,7 @@ def test_dataframe(simple_rint, batched):
 
     # Ensure that the sign convention is the HDF5 is opposite of the dataframe in the moirae convention
     assert len(output[0].raw_data) == len(df) // rint_asoh.batch_size
-    assert np.allclose(output[0].raw_data['current'], -df.query('batch == 0')['current'])
+    assert np.allclose(output[0].raw_data['current'], df.query('batch == 0')['current'])
     assert np.allclose(output[0].raw_data['test_time'], df.query('batch == 0')['time'])
 
 


### PR DESCRIPTION
1. Rename imports
2. Adjust how subdatasets are accessed
3. Adjust metadata definitions
4. Flip sign convention