### PR TITLE
Switch from h5py to pytables

### DIFF
--- a/moirae/interface/hdf5.py
+++ b/moirae/interface/hdf5.py
@@ -6,8 +6,8 @@ import json
 
 from flatten_dict import flatten
 from pydantic import BaseModel, Field, PrivateAttr
+import tables as tb
 import numpy as np
-import h5py
 
 from moirae.estimators.online import OnlineEstimator, MultivariateRandomDistribution
 from moirae.estimators.online.filters.distributions import MultivariateGaussian, DeltaDistribution
@@ -43,9 +43,8 @@ class HDF5Writer(BaseModel, AbstractContextManager, arbitrary_types_allowed=True
     Args:
         hdf5_output: Path to an HDF5 file or group within a file in which to write data
         storage_key: Name of the group within the file to store all states
-        dataset_options: Option used when initializing storage. See :meth:`~h5py.Group.create_dataset`.
+        table_options: Option used when initializing storage. See :meth:`~h5py.Group.create_dataset`.
             Default is to use LZF compression.
-        resizable: Whether to allow the file to be shrunk or expanded
         per_timestep: Which information to store at each timestep:
             - `full`: All available information about the estimated state
             - `mean_cov`: The mean and covariance of the estimated state
@@ -57,16 +56,12 @@ class HDF5Writer(BaseModel, AbstractContextManager, arbitrary_types_allowed=True
     """
 
     # Attributes defining where and how to write
-    hdf5_output: Union[Path, str, h5py.Group] = Field(exclude=True)
+    hdf5_output: Union[Path, str, tb.Group] = Field(exclude=True)
     """File or already-open HDF5 file in which to store data"""
-    file_options: Dict[str, Any] = Field(default_factory=lambda: dict(rdcc_nbytes=1024 ** 2 * 16, rdcc_w0=0))
-    """Options employed when opening the HDFt file. See :meth:`~h5py.File`"""
     storage_key: str = 'state_estimates'
-    """Name of the group in which to store the estimates"""
-    dataset_options: Dict[str, Any] = Field(default_factory=lambda: dict(compression='lzf'))
+    """Name of the group in which to store the estimates. Ignored if :attr:`hdf5_output` is a Group"""
+    table_options: Dict[str, Any] = Field(default_factory=lambda: dict(complib='lzo', complevel=5))
     """Option used when initializing storage. See :meth:`~h5py.Group.create_dataset`"""
-    resizable: bool = True
-    """Whether to use `resizable datasets <https://docs.h5py.org/en/stable/high/dataset.html#resizable-datasets>`_."""
 
     # Attributes defining what is written
     per_timestep: OutputType = 'mean'
@@ -75,22 +70,22 @@ class HDF5Writer(BaseModel, AbstractContextManager, arbitrary_types_allowed=True
     """What information to store at the first timestep each cycle"""
 
     # State used only while in writing mode
-    _file_handle: Optional[h5py.File] = PrivateAttr(None)
+    _file_handle: Optional[tb.File] = PrivateAttr(None)
     """Handle to an open file"""
-    _group_handle: Optional[h5py.Group] = PrivateAttr(None)
+    _group_handle: Optional[tb.Group] = PrivateAttr(None)
     """Handle to the group being written to"""
+    _table_map: Dict[str, tb.Table] = PrivateAttr(default_factory=dict)
+    """Map of the currently-open tables"""
     position: Optional[int] = None
     """Index of the next step to be written"""
 
     def __enter__(self):
         """Open the file and store the group in which to write data"""
-        if not isinstance(self.hdf5_output, h5py.Group):
-            root = self._file_handle = h5py.File(self.hdf5_output, mode='a', **self.file_options)
+        if not isinstance(self.hdf5_output, tb.Group):
+            self._file_handle = tb.open_file(self.hdf5_output, mode='a')
+            self._group_handle = self._file_handle.create_group('/', self.storage_key)
         else:
-            root = self.hdf5_output
-        if self.storage_key not in root:
-            root.create_group(self.storage_key)
-        self._group_handle = root.get(self.storage_key)
+            self._group_handle = self.hdf5_output
         self.position = 0  # TODO (wardlt): Support re-opening files for writing phase
         return self
 
@@ -100,6 +95,7 @@ class HDF5Writer(BaseModel, AbstractContextManager, arbitrary_types_allowed=True
             self._file_handle.close()
             self._file_handle = None
         self._group_handle = None
+        self._table_map.clear()
 
     @property
     def is_ready(self) -> bool:
@@ -126,18 +122,16 @@ class HDF5Writer(BaseModel, AbstractContextManager, arbitrary_types_allowed=True
               expected_cycles: Expected number of cycles.
         """
         self._check_if_ready()
-        if not self.resizable and (expected_steps is None or expected_cycles is None):
-            raise ValueError('Expected sizes must be provided if not writing in resizable mode')
 
         # Put the metadata in the attributes of the group
-        self._group_handle.attrs['write_settings'] = self.model_dump_json(exclude={'hdf5_output'})
-        self._group_handle.attrs['state_names'] = estimator.state_names
-        self._group_handle.attrs['output_names'] = estimator.output_names
-        self._group_handle.attrs['estimator_name'] = estimator.__class__.__name__
-        self._group_handle.attrs['distribution_type'] = estimator.state.__class__.__name__
-        self._group_handle.attrs['cell_model'] = estimator.cell_model.__class__.__name__
-        self._group_handle.attrs['initial_asoh'] = estimator.asoh.model_dump_json()
-        self._group_handle.attrs['initial_transient_state'] = estimator.transients.model_dump_json()
+        self._group_handle._v_attrs['write_settings'] = self.model_dump_json(exclude={'hdf5_output'})
+        self._group_handle._v_attrs['state_names'] = estimator.state_names
+        self._group_handle._v_attrs['output_names'] = estimator.output_names
+        self._group_handle._v_attrs['estimator_name'] = estimator.__class__.__name__
+        self._group_handle._v_attrs['distribution_type'] = estimator.state.__class__.__name__
+        self._group_handle._v_attrs['cell_model'] = estimator.cell_model.__class__.__name__
+        self._group_handle._v_attrs['initial_asoh'] = estimator.asoh.model_dump_json()
+        self._group_handle._v_attrs['initial_transient_state'] = estimator.transients.model_dump_json()
 
         # Update accordingly
         state = estimator.state
@@ -152,21 +146,18 @@ class HDF5Writer(BaseModel, AbstractContextManager, arbitrary_types_allowed=True
             if what == "none":
                 continue
             to_insert = {'time': np.array(0.)}
+            if where == 'per_cycle':
+                to_insert['cycle'] = np.array(0, dtype=np.uint32)
             to_insert.update(_convert_state_to_numpy_dict(state, what, 'state'))
             to_insert.update(_convert_state_to_numpy_dict(output, what, 'output'))
 
-            # Create datasets
-            if where in self._group_handle:
-                raise ValueError(f'File contains {self.storage_key}/{where} group. Overwriting not yet supported')
-            my_group = self._group_handle.create_group(where)
-            for key, value in to_insert.items():
-                if self.resizable:
-                    starting_size = 128 if expected is None else expected
-                    my_kwargs = {'shape': (starting_size, *value.shape), 'maxshape': (expected, *value.shape)}
-                else:
-                    my_kwargs = {'shape': (expected, *value.shape)}
-
-                my_group.create_dataset(key, dtype=value.dtype, fillvalue=np.nan, **my_kwargs, **self.dataset_options)
+            # Make the table
+            table_dtype = np.dtype([(k, v.dtype, v.shape) for k, v in to_insert.items()])
+            filters = tb.Filters(**self.table_options)
+            self._table_map[where] = self._file_handle.create_table(self._group_handle,
+                                                                    name=where,
+                                                                    description=table_dtype,
+                                                                    filters=filters)
 
     def append_step(self,
                     time: float,
@@ -191,33 +182,29 @@ class HDF5Writer(BaseModel, AbstractContextManager, arbitrary_types_allowed=True
             # Determine if we must write
             if what == "none":
                 continue
-            my_group = self._group_handle[where]
+            my_table = self._table_map[where]
 
             # Only write the first state for each cycle
-            if where == "per_cycle" and ind < my_group['time'].shape[0] and not np.isnan(my_group['time'][ind]):
+            if where == "per_cycle" and my_table.shape[0] != 0 and my_table[-1]['cycle'] == ind:
                 continue
 
-            # Determine what to write
+            # Make the row to be inserted
             to_insert = {'time': np.array(time)}
+            if where == "per_cycle":
+                to_insert['cycle'] = ind
             to_insert.update(_convert_state_to_numpy_dict(state, what, 'state'))
             to_insert.update(_convert_state_to_numpy_dict(output, what, 'output'))
 
-            # Write it
-            for key, value in to_insert.items():
-                my_dataset: h5py.Dataset = my_group[key]
-
-                # Expand by one chunk size if necessary
-                if my_dataset.shape[0] <= ind:
-                    my_dataset.resize(my_dataset.shape[0] + my_dataset.chunks[0], axis=0)
-
-                my_ind = (ind,) + (slice(None),) * value.ndim
-                my_dataset[my_ind] = value
+            row = np.empty((1,), dtype=my_table.dtype)
+            for k, v in to_insert.items():
+                row[k] = v
+            my_table.append(row)
 
         # Increment the step position
         self.position += 1
 
 
-def read_state_estimates(data_path: Union[str, Path, h5py.Group],
+def read_state_estimates(data_path: Union[str, Path, tb.Group],
                          per_timestep: bool = True,
                          dist_type: type[MultivariateRandomDistribution] = MultivariateGaussian
                          ) -> Iterator[tuple[float, MultivariateRandomDistribution, MultivariateRandomDistribution]]:
@@ -226,7 +213,7 @@ def read_state_estimates(data_path: Union[str, Path, h5py.Group],
 
     Args:
         data_path: Path to the HDF5 file or the group holding state estimates from an already-open file.
-        per_timestep: Whether to read per-timestep rather than per-cycle estiamtes
+        per_timestep: Whether to read per-timestep rather than per-cycle estimates
         dist_type: Distribution type to create if the "full" distribution is stored
 
     Yields:
@@ -238,9 +225,9 @@ def read_state_estimates(data_path: Union[str, Path, h5py.Group],
     # Open the file and access the group holding the state estimates
     file = None
     if isinstance(data_path, (str, Path)):
-        file = h5py.File(data_path, mode='r')
+        file = tb.open_file(data_path, mode='r')
         try:
-            se_group = file['state_estimates']
+            se_group = file.root['state_estimates']
         except ValueError:
             file.close()
             raise
@@ -250,9 +237,9 @@ def read_state_estimates(data_path: Union[str, Path, h5py.Group],
     try:
         # Access the target group to read from
         tag = 'per_timestep' if per_timestep else 'per_cycle'
-        read_type = json.loads(se_group.attrs['write_settings'])[tag]
+        read_type = json.loads(se_group._v_attrs['write_settings'])[tag]
         if read_type == 'full':
-            if dist_type.__name__ != (stored_type := se_group.attrs['distribution_type']):
+            if dist_type.__name__ != (stored_type := se_group._v_attrs['distribution_type']):
                 # TODO (wardlt): Have Moriae load the correct one automatically
                 raise ValueError(f'Estimates were stored as a {stored_type}'
                                  f' but you provided dist_type={dist_type.__name__}')
@@ -267,28 +254,26 @@ def read_state_estimates(data_path: Union[str, Path, h5py.Group],
         data_group = se_group[tag]
 
         # Read what data are available
-        data_keys = list(data_group.keys())
+        data_keys = list(data_group.dtype.fields)
         data_keys.remove('time')
 
         # Yield the data from the file
-        def _unpack(ind, typ):
-            values = dict((k[len(typ):], data_group[k][ind]) for k in data_keys if k.startswith(typ))
+        def _unpack(row, typ):
+            values = dict((k[len(typ):], row[k]) for k in data_keys if k.startswith(typ))
 
             # Expand variance to covariance
             if read_type == 'mean_var':
                 values['covariance'] = np.diag(values.pop('variance'))
             return values
 
-        for i, time in enumerate(data_group['time']):
-            if np.isnan(time):  # NaN marks the end of the data
-                return
+        for i, row in enumerate(data_group):
             # Unpack the dists
-            state_values = _unpack(i, 'state_')
+            state_values = _unpack(row, 'state_')
             state_dist = dist_type(**state_values)
 
-            output_values = _unpack(i, 'output_')
+            output_values = _unpack(row, 'output_')
             output_dist = dist_type(**output_values)
-            yield time, state_dist, output_dist
+            yield row['time'], state_dist, output_dist
     finally:
         if file is not None:
             file.close()

--- a/performance-tests/visualize-performance-data.ipynb
+++ b/performance-tests/visualize-performance-data.ipynb
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 32,
    "id": "a52518ab-521f-4011-9dca-dbe8a6704960",
    "metadata": {},
    "outputs": [
@@ -40,7 +40,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Loaded 3 run tests\n"
+      "Loaded 6 run tests\n"
      ]
     }
    ],
@@ -59,7 +59,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 33,
    "id": "5f1f9040-4de8-450b-a641-49f7cebeae89",
    "metadata": {},
    "outputs": [
@@ -67,7 +67,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Tested 1 versions. Latest, cf5bd824bb2b5fb0eefc97deda54c84ffdb175d4, ran starting 2025-01-15 12:20:51.541267\n"
+      "Tested 2 versions. Latest, d82aad4a9bbb4d6fe6f7df0a5a0538dd1735d478, ran starting 2025-01-15 15:54:32.834912\n"
      ]
     }
    ],
@@ -88,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 34,
    "id": "11f41edf-f255-43ff-9363-2cd700279bd8",
    "metadata": {},
    "outputs": [
@@ -107,7 +107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 35,
    "id": "fd17016c-a5cf-4d7d-b2d0-68d763873b18",
    "metadata": {},
    "outputs": [
@@ -157,24 +157,24 @@
        "      <th rowspan=\"3\" valign=\"top\">camp</th>\n",
        "      <th rowspan=\"3\" valign=\"top\">ecm</th>\n",
        "      <th>joint</th>\n",
-       "      <td>none</td>\n",
-       "      <td>none</td>\n",
-       "      <td>0.349856</td>\n",
-       "      <td>298.489671</td>\n",
+       "      <td>mean</td>\n",
+       "      <td>full</td>\n",
+       "      <td>0.265466</td>\n",
+       "      <td>119.161336</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>joint</th>\n",
        "      <td>none</td>\n",
        "      <td>full</td>\n",
-       "      <td>0.376738</td>\n",
-       "      <td>448.651664</td>\n",
+       "      <td>0.290513</td>\n",
+       "      <td>121.746162</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>joint</th>\n",
        "      <td>mean</td>\n",
        "      <td>full</td>\n",
-       "      <td>0.366231</td>\n",
-       "      <td>1047.588005</td>\n",
+       "      <td>0.208443</td>\n",
+       "      <td>127.369466</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -183,18 +183,18 @@
       "text/plain": [
        "                                  timestep_write_level cycle_write_level  \\\n",
        "hostname  dataset model estimator                                          \n",
-       "CSI365712 camp    ecm   joint                     none              none   \n",
+       "CSI365712 camp    ecm   joint                     mean              full   \n",
        "                        joint                     none              full   \n",
        "                        joint                     mean              full   \n",
        "\n",
-       "                                   read_time     run_time  \n",
-       "hostname  dataset model estimator                          \n",
-       "CSI365712 camp    ecm   joint       0.349856   298.489671  \n",
-       "                        joint       0.376738   448.651664  \n",
-       "                        joint       0.366231  1047.588005  "
+       "                                   read_time    run_time  \n",
+       "hostname  dataset model estimator                         \n",
+       "CSI365712 camp    ecm   joint       0.265466  119.161336  \n",
+       "                        joint       0.290513  121.746162  \n",
+       "                        joint       0.208443  127.369466  "
       ]
      },
-     "execution_count": 21,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
I must have been doing something wrong with h5py. PyTables is like 10x faster for streaming to disk

Closes #103 because writes are no longer a problem. Let's keep H5 for the output type.