### PR TITLE
Add serialization and validation logic for SOC pinpoints

### DIFF
--- a/moirae/models/base.py
+++ b/moirae/models/base.py
@@ -56,6 +56,10 @@ ListParameter = Annotated[
 ]
 """Type annotation for parameters which can be any number of values"""
 
+NumpyType = Annotated[
+    np.ndarray, BeforeValidator(np.array), Field(), WrapSerializer(_encode_ndarray, when_used='json-unless-none')
+]
+
 
 # TODO (wardlt): Decide on what we call a parameter and a variable (or, rather, adopt @vventuri's terminology)
 # TODO (wardlt): Make an "expand names" function to turn the name of a subvariable to a list of updatable names

--- a/moirae/models/base.py
+++ b/moirae/models/base.py
@@ -59,6 +59,7 @@ ListParameter = Annotated[
 NumpyType = Annotated[
     np.ndarray, BeforeValidator(np.array), Field(), WrapSerializer(_encode_ndarray, when_used='json-unless-none')
 ]
+"""Type annotation for a field which is a numpy array but does not requires the batch dimensions used by parameters"""
 
 
 # TODO (wardlt): Decide on what we call a parameter and a variable (or, rather, adopt @vventuri's terminology)

--- a/moirae/models/ecm/utils.py
+++ b/moirae/models/ecm/utils.py
@@ -2,10 +2,10 @@ from typing import List, Optional, Union, Literal, Callable, Iterator
 from numbers import Number
 
 import numpy as np
-from pydantic import Field, field_serializer
+from pydantic import Field
 from scipy.interpolate import interp1d
 
-from moirae.models.base import HealthVariable, ListParameter
+from moirae.models.base import HealthVariable, ListParameter, NumpyType
 
 
 class SOCInterpolatedHealth(HealthVariable):
@@ -13,14 +13,10 @@ class SOCInterpolatedHealth(HealthVariable):
     """
     base_values: ListParameter = \
         Field(default=0, description='Values at specified SOCs')
-    soc_pinpoints: Optional[np.ndarray] = Field(default=None, description='SOC pinpoints for interpolation.')
+    soc_pinpoints: Optional[NumpyType] = Field(default=None, description='SOC pinpoints for interpolation.')
     interpolation_style: Literal['linear', 'nearest', 'nearest-up', 'zero', 'slinear',
                                  'quadratic', 'cubic', 'previous', 'next'] = \
         Field(default='linear', description='Type of interpolation to perform')
-
-    @field_serializer('soc_pinpoints', when_used='json-unless-none')
-    def _serialize_numpy(self, value: np.ndarray):
-        return value.tolist()
 
     def iter_parameters(self, updatable_only: bool = True, recurse: bool = True) -> Iterator[tuple[str, np.ndarray]]:
         for name, param in super().iter_parameters(updatable_only, recurse):


### PR DESCRIPTION
Fixes #120 by adding proper handling for serialization and validation of a numpy array. Switches the pydantic serialization logic from the class-method style to the `Annotated` style we're using elsewhere in Moirae.