### PR TITLE
Adds log-likelihood to distributions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,6 @@ cython_debug/
 
 # Development tests
 notebooks/demonstrate_ignorance.ipynb
+
+# Editor settings
+.vscode

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,7 +75,7 @@ def make_dataset(simple_rint):
 
     # Make metadata with a cell capacity
     metadata = BatteryMetadata(
-        battery=BatteryDescription(nominal_capacity=rint_asoh.q_t.amp_hour)
+        battery=BatteryDescription(nominal_capacity=rint_asoh.q_t.amp_hour.item())
     )
 
     return CellDataset(raw_data=raw_data, metadata=metadata)
@@ -172,7 +172,7 @@ def make_dataset_hppc(simple_rint):
 
     # Make metadata with a cell capacity
     metadata = BatteryMetadata(
-        battery=BatteryDescription(nominal_capacity=asoh.q_t.amp_hour)
+        battery=BatteryDescription(nominal_capacity=asoh.q_t.amp_hour.item())
     )
 
     # CellDataset(

--- a/tests/estimators/online/filters/test_distributions.py
+++ b/tests/estimators/online/filters/test_distributions.py
@@ -74,7 +74,7 @@ def test_log_likelihood():
 
     # Delta
     delta = DeltaDistribution(mean=np.array([5., 6.]))
-    delta_log_like = delta.compute_log_likelihook(data=data)
+    delta_log_like = delta.compute_log_likelihood(data=data)
     expected = -np.inf * np.ones(len(data))
     expected[1] = 0.
     assert np.allclose(delta_log_like, expected), \
@@ -86,7 +86,7 @@ def test_log_likelihood():
     ind_gauss = MultivariateGaussian(mean=mean, covariance=cov)
     # Create a similar one with scipy stats
     mv_ind_gauss = multivariate_normal(mean=mean, cov=cov)
-    ind_log_like = ind_gauss.compute_log_likelihook(data=data)
+    ind_log_like = ind_gauss.compute_log_likelihood(data=data)
     assert np.allclose(ind_log_like[1], -np.log(2 * np.pi)), f'Unexpected likelihood for the mean: {ind_log_like[1]}!'
     assert ind_log_like[0] == ind_log_like[-1], f'Independent Gaussian likelihood not symmetric: {ind_log_like}'
     assert np.allclose(ind_log_like, np.log(mv_ind_gauss.pdf(data))), f'{mv_ind_gauss.pdf(data)}'
@@ -95,7 +95,7 @@ def test_log_likelihood():
     ind_gauss = MultivariateGaussian(mean=mean, covariance=cov)
     # Create a similar one with scipy stats
     mv_cor_gauss = multivariate_normal(mean=mean, cov=cov)
-    cor_log_like = ind_gauss.compute_log_likelihook(data=data)
+    cor_log_like = ind_gauss.compute_log_likelihood(data=data)
     mean_likelihood = -np.log(2 * np.pi) - (0.5 * np.log(1.75))
     assert np.allclose(cor_log_like[1], mean_likelihood), f'Unexpected likelihood for the mean: {cor_log_like[1]}!'
     assert cor_log_like[0] == cor_log_like[-1], f'Correlated Gaussian likelihood not symmetric: {cor_log_like}'

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -125,7 +125,7 @@ def _make_simple_hf_estimates(simple_rint, what, tmpdir):
         # Write two states to the file
         writer.append_step(0., 0, estimator.state, example_output)
 
-        new_state = estimator.state.copy(deep=True)
+        new_state = estimator.state.model_copy(deep=True)
         new_state.mean = estimator.state.get_mean() + 0.1
         writer.append_step(1., 0, new_state, example_output)
     return h5_path, estimator.state, new_state


### PR DESCRIPTION
Now, the main objects used by filters should also be able to compute the log-likelihood of a given set of datapoints, making it easier to develop metrics. 