### PR TITLE
Revise detecting and iterating over health parameters

### DIFF
--- a/moirae/models/base.py
+++ b/moirae/models/base.py
@@ -50,7 +50,7 @@ def _encode_ndarray(value: np.ndarray, handler) -> List:
 
 ScalarParameter = Annotated[
     np.ndarray,
-    'moirae_parameter',
+    Field(json_schema_extra={'type': 'moirae_parameter'}),
     BeforeValidator(lambda x: enforce_dimensions(x, 0)), Field(validate_default=True),
     WrapSerializer(_encode_ndarray, when_used='json-unless-none')
 ]
@@ -58,7 +58,7 @@ ScalarParameter = Annotated[
 
 ListParameter = Annotated[
     np.ndarray,
-    'moirae_parameter',
+    Field(json_schema_extra={'type': 'moirae_parameter'}),
     BeforeValidator(lambda x: enforce_dimensions(x, 1)), Field(validate_default=True),
     WrapSerializer(_encode_ndarray, when_used='json-unless-none')
 ]
@@ -92,7 +92,7 @@ class HealthVariable(BaseModel, arbitrary_types_allowed=True):
         output = []
         for field, info in self.__class__.model_fields.items():
             # Simple case: it's a parameter
-            if info.annotation == np.ndarray and 'moirae_parameter' in info.metadata:
+            if info.annotation == np.ndarray and info.json_schema_extra.get('type') == 'moirae_parameter':
                 output.append((field, 'parameter'))
             elif get_origin(info.annotation) is None and issubclass(info.annotation, HealthVariable):
                 output.append((field, 'variable'))

--- a/moirae/models/ecm/utils.py
+++ b/moirae/models/ecm/utils.py
@@ -1,5 +1,5 @@
 """Functions used in multiple components"""
-from typing import List, Optional, Union, Literal, Callable, Iterator
+from typing import List, Optional, Union, Literal, Callable
 from numbers import Number
 
 import numpy as np
@@ -22,11 +22,6 @@ class SOCInterpolatedHealth(HealthVariable):
     # Internal caches
     _ppoly_cache: tuple[np.ndarray, np.ndarray, Callable] | None = PrivateAttr(None)
     """Cache for the interpolation function, and the interpolation points/soc points at which it was produced"""
-
-    def iter_parameters(self, updatable_only: bool = True, recurse: bool = True) -> Iterator[tuple[str, np.ndarray]]:
-        for name, param in super().iter_parameters(updatable_only, recurse):
-            if name != "soc_pinpoints":
-                yield name, param
 
     def _get_function(self) -> Callable:
         """Retrieve the interpolation function

--- a/tests/extractors/test_ecm_rc.py
+++ b/tests/extractors/test_ecm_rc.py
@@ -29,7 +29,7 @@ def test_data_check(rc_dataset, rc_extractor):
 
 
 def test_spline_fit(rc_dataset, rc_extractor):
-    rc_points = rc_extractor.interpolate_rc(rc_dataset)  # .tables['raw_data'])
+    rc_points = rc_extractor.interpolate_rc(rc_dataset)
 
     expected_rc = unrealistic_fake_rc(rc_extractor.soc_points)
 

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -34,6 +34,11 @@ def example_hv() -> ExampleHealthVariable:
     )
 
 
+def test_field_names(example_hv):
+    names = example_hv.all_fields
+    assert names == ('a', 'b', 'c', 'd', 'e')
+
+
 def test_parameter_iterator(example_hv):
     """Test the iterator over parameters"""
 

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -35,8 +35,9 @@ def example_hv() -> ExampleHealthVariable:
 
 
 def test_field_names(example_hv):
-    names = example_hv.all_fields
+    names, field_types = zip(*example_hv.all_fields_with_types)
     assert names == ('a', 'b', 'c', 'd', 'e')
+    assert field_types == ('parameter', 'parameter', 'variable', 'sequence', 'dict')
 
 
 def test_parameter_iterator(example_hv):


### PR DESCRIPTION
Fix a few issues:
- [x] `self.model_fields` is deprecated in Pydantic
- [x] Mark health parameters explicitly rather than assume all numpy arrays
- [x] Reduce the amount we test types of objects

The change is to add two properties to `HealthVariable`, `all_fields` and `all_fields_with_types`, that hold the logic to determine which fields (attributes) of the HealthVariable map to health parameters. 

How parameters are detected is slightly changed: it looks for numpy arrays tagged with "moirae_parameter" via Annotated tagging and HealthVariables (or collections of them) are found by explicitly testing whether a type is a `Tuple[HealthParameter]` or `Dict[str, HealthParameter]` via Python's issubclass logic.