### PR TITLE
Tweak how temperature is handled in Thevenin

### DIFF
--- a/docs/source/cell-models/thevenin.rst
+++ b/docs/source/cell-models/thevenin.rst
@@ -14,14 +14,6 @@ Transient and State of Health (``moirae.models.thevenin.state``)
    :undoc-members:
    :show-inheritance:
 
-Components (``moirae.models.thevenin.components``)
-++++++++++++++++++++++++++++++++++++++++++++++++++
-
-.. automodule:: moirae.models.thevenin.components
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 Inputs and Outputs (``moirae.models.thevenin.ins_outs``)
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -31,9 +31,16 @@ Reusable Components (``moirae.models.components``)
    :members:
    :show-inheritance:
 
-State Dependent ASOH (``moirae.models.components.soc``)
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++
+SOC-Dependent ASOH (``moirae.models.components.soc``)
++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. automodule:: moirae.models.components.soc
+   :members:
+   :show-inheritance:
+
+(SOC,T)-Dependent ASOH (``moirae.models.components.soc``)
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. automodule:: moirae.models.components.soc_t
    :members:
    :show-inheritance:

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -13,4 +13,3 @@ API documentation for each module
    models
    interface
    simulator
-   version

--- a/moirae/models/components/soc_t.py
+++ b/moirae/models/components/soc_t.py
@@ -23,7 +23,8 @@ class SOCTempDependentHealth(HealthVariable, metaclass=ABCMeta):
                    equal to the batch size fo the parameters.
                 2. a 1D array of shape `(soc_dim,)`, in which case we will consider the `batch_size` to be equal to 1
                 3. a 0D array (a scalar), in which case both `batch_size` and `soc_dim` are equal to 1.
-            temp: Temperatures at which to evaluate the property. Dimensions follow the same format as ``soc``.
+            temp: Temperatures at which to evaluate the property. (Units: °C)
+                 Dimensions follow the same format as ``soc``.
             batch_id: Which batch member for the parameters and input SOC values to use. Default is to use whole batch
         Returns:
             Interpolated values as a 2D with dimensions (batch_size, soc_points).
@@ -45,8 +46,8 @@ class SOCTempPolynomialHealth(SOCTempDependentHealth):
     """
 
     # TODO (wardlt): We define a constant parameter in both polynomials. Maybe set one have an assumed constant of zero
-    t_ref: ScalarParameter = 298.
-    """Reference temperature for the temperature dependence. Units: K"""
+    t_ref: ScalarParameter = 25.
+    """Reference temperature for the temperature dependence. Units: °C"""
     soc_coeffs: ListParameter = 1.
     """Reference parameters for the OCV dependence polynomial"""
     t_coeffs: ListParameter = 0.

--- a/moirae/models/thevenin/ins_outs.py
+++ b/moirae/models/thevenin/ins_outs.py
@@ -6,4 +6,4 @@ class TheveninInput(InputQuantities):
     """Inputs for the Thevenin model"""
 
     t_inf: ScalarParameter = 298.
-    """Environmental temperature (units: K)"""
+    """Environmental temperature (units: °C)"""

--- a/moirae/models/thevenin/ins_outs.py
+++ b/moirae/models/thevenin/ins_outs.py
@@ -5,5 +5,5 @@ from moirae.models.base import InputQuantities, ScalarParameter
 class TheveninInput(InputQuantities):
     """Inputs for the Thevenin model"""
 
-    t_inf: ScalarParameter = 298.
+    t_inf: ScalarParameter = 25.
     """Environmental temperature (units: °C)"""

--- a/moirae/models/thevenin/state.py
+++ b/moirae/models/thevenin/state.py
@@ -38,7 +38,7 @@ class TheveninASOH(HealthVariable):
     )
     """Resistance all resistors, including both the series resistor and those in RC elements (Ohm)"""
     c: Tuple[SOCTempDependentHealth, ...] = Field(default_factory=tuple)
-    """Capacitance in all RC elements (C)"""
+    """Capacitance in all RC elements (F)"""
     ce: ScalarParameter = 1.
     """Coulomb efficiency"""
     gamma: ScalarParameter = 50.

--- a/moirae/models/thevenin/state.py
+++ b/moirae/models/thevenin/state.py
@@ -22,29 +22,29 @@ class TheveninASOH(HealthVariable):
 
     # Default parameters from: test_model.py in thevenin
     capacity: ScalarParameter = 1.
-    """Maximum battery capacity (A-hr)"""
+    """Maximum battery capacity. Units: A-hr"""
     mass: ScalarParameter = 0.1
-    """Total battery mass of a battery (kg)"""
+    """Total battery mass of a battery. Units: kg"""
     c_p: ScalarParameter = 1150.
-    """Specific heat capacity (J/kg/K)"""
+    """Specific heat capacity. Units: J/kg/K"""
     h_thermal: ScalarParameter = 12
-    """Convective coefficient (W/m^2/K)"""
+    """Convective coefficient. Units: W/m^2/K"""
     a_therm: ScalarParameter = 1
-    """Heat loss area (m^2)"""
+    """Heat loss area. Units: m^2"""
     ocv: SOCDependentHealth = Field(default_factory=lambda: SOCPolynomialHealth(coeffs=3.5))
-    """Open circuit voltage (V)"""
+    """Open circuit voltage. Units: V"""
     r: Tuple[SOCTempDependentHealth, ...] = Field(
         default_factory=lambda: (SOCTempPolynomialHealth(soc_coeffs=0.1),), min_length=1
     )
-    """Resistance all resistors, including both the series resistor and those in RC elements (Ohm)"""
+    """Resistance all resistors, including both the series resistor and those in RC elements. Units: Ohm"""
     c: Tuple[SOCTempDependentHealth, ...] = Field(default_factory=tuple)
-    """Capacitance in all RC elements (F)"""
+    """Capacitance in all RC elements. Units: F"""
     ce: ScalarParameter = 1.
     """Coulomb efficiency"""
     gamma: ScalarParameter = 50.
     """Hysteresis approach rate"""
     m_hyst: SOCDependentHealth = Field(default_factory=lambda: SOCPolynomialHealth(coeffs=0))
-    """Maximum magnitude of hysteresis (V)"""
+    """Maximum magnitude of hysteresis. Units: V"""
 
     @property
     def num_rc_elements(self) -> int:
@@ -63,15 +63,15 @@ class TheveninTransient(GeneralContainer):
 
     soc: ScalarParameter = 0.
     """State of charge for the battery system"""
-    temp: ScalarParameter = 298.
-    """Temperature of the battery (units: K)"""
+    cell_temperature: ScalarParameter = 25.
+    """Temperature of the battery. Units: °C"""
     hyst: ScalarParameter = 0.
-    """Hysteresis voltage (units: V)"""
+    """Hysteresis voltage. Units: V"""
     eta: ListParameter = ()
-    """Overpotential for the RC elements (units: V)"""
+    """Overpotential for the RC elements. Units: V"""
 
     @classmethod
-    def from_asoh(cls, asoh: TheveninASOH, soc: float = 0., temp: float = 298.) -> 'TheveninTransient':
+    def from_asoh(cls, asoh: TheveninASOH, soc: float = 0., temp: float = 25.) -> 'TheveninTransient':
         """
         Create a transient state appropriate for the circuit defined in a :class:`TheveninASOH`.
 
@@ -85,4 +85,4 @@ class TheveninTransient(GeneralContainer):
         """
 
         eta = np.zeros((1, asoh.num_rc_elements))
-        return cls(soc=soc, temp=temp, eta=eta)
+        return cls(soc=soc, cell_temperature=temp, eta=eta)

--- a/tests/models/test_components.py
+++ b/tests/models/test_components.py
@@ -229,19 +229,19 @@ def test_soc_temp_dependence():
     comp = SOCTempPolynomialHealth(soc_coeffs=[[1, 0.5], [0.5, 0.25]], t_coeffs=[[0, -0.1]])
 
     # Make sure it works with scalars for a single batch, as needed by Thevenin to update
-    y = comp.get_value(0.5, 299, batch_id=0)
+    y = comp.get_value(0.5, 26, batch_id=0)
     assert y.shape == (1, 1)
     assert np.isclose(y, 1.15)
 
-    y = comp.get_value(0.5, 299, batch_id=1)
+    y = comp.get_value(0.5, 26, batch_id=1)
     assert y.shape == (1, 1)
     assert np.isclose(y, 0.525)
 
     # Make sure it works with 2D inputs and all batches, as when computing terminal voltage
-    y = comp.get_value(np.array([0.5]), np.array([299]))
+    y = comp.get_value(np.array([0.5]), np.array([26]))
     assert y.shape == (2, 1)
     assert np.allclose(y, [[1.15], [0.525]])
 
-    y = comp.get_value(np.array([[0.5], [0.]]), np.array([299]))
+    y = comp.get_value(np.array([[0.5], [0.]]), np.array([26]))
     assert y.shape == (2, 1)
     assert np.allclose(y, [[1.15], [0.4]])

--- a/tests/models/test_thevenin.py
+++ b/tests/models/test_thevenin.py
@@ -32,24 +32,24 @@ def test_rint():
     assert rint.ocv.get_value(0.5, batch_id=0) == 2.
 
     # Ensuring we can do SOC and temperature dependence
-    assert rint.r[0].get_value(0.5, 298, batch_id=0) == 0.015
-    assert rint.r[0].get_value(0.5, 308, batch_id=0) == 0.025
+    assert rint.r[0].get_value(0.5, 25, batch_id=0) == 0.015
+    assert rint.r[0].get_value(0.5, 35, batch_id=0) == 0.025
 
     # Test a single step at constant current
-    state = TheveninTransient(soc=0., temp=298.)
-    pre_inputs = TheveninInput(current=1., time=0., t_inf=298.)
-    new_inputs = TheveninInput(current=1., time=30., t_inf=298.)
+    state = TheveninTransient(soc=0., cell_temperature=25.)
+    pre_inputs = TheveninInput(current=1., time=0., t_inf=25.)
+    new_inputs = TheveninInput(current=1., time=30., t_inf=25.)
 
     model = TheveninModel()
     new_state = model.update_transient_state(pre_inputs, new_inputs, state, rint)
     assert new_state.batch_size == 1
     assert np.allclose(new_state.soc.item(), 30 / 3600.)
-    assert new_state.temp > state.temp  # Solving for the actual answer is annoying
+    assert new_state.cell_temperature > state.cell_temperature  # Solving for the actual answer is annoying
 
     # Get the terminal voltage
     voltage = model.calculate_terminal_voltage(new_inputs, new_state, rint)
     assert voltage.batch_size == 1
-    assert np.allclose(voltage.terminal_voltage, (1.5 + 30 / 3600) + rint.r[0].get_value(30 / 3600, 298))
+    assert np.allclose(voltage.terminal_voltage, (1.5 + 30 / 3600) + rint.r[0].get_value(30 / 3600, 25))
 
 
 @mark.parametrize('asoh', [rint, rc2])
@@ -58,8 +58,8 @@ def test_multiple_steps(asoh):
 
     # Test a single step at constant current
     state = TheveninTransient.from_asoh(asoh)
-    pre_inputs = TheveninInput(current=1., time=0., t_inf=298.)
-    new_inputs = TheveninInput(current=1., time=30., t_inf=298.)
+    pre_inputs = TheveninInput(current=1., time=0., t_inf=25.)
+    new_inputs = TheveninInput(current=1., time=30., t_inf=25.)
 
     # Test a single step of 30s charging
     model = TheveninModel()
@@ -73,44 +73,44 @@ def test_multiple_steps(asoh):
 
     # Test charging until the full hour
     pre_inputs = new_inputs
-    new_inputs = TheveninInput(current=1., time=3600., t_inf=298.)
+    new_inputs = TheveninInput(current=1., time=3600., t_inf=25.)
     state = model.update_transient_state(pre_inputs, new_inputs, state, asoh)
     assert np.allclose(state.soc, 1.)
     assert np.less(state.eta, 0.).all()
-    assert np.greater(state.temp, 298.).all()
+    assert np.greater(state.cell_temperature, 25.).all()
 
     v = model.calculate_terminal_voltage(new_inputs, state, asoh)
     assert np.greater_equal(v.terminal_voltage, 2.5 + 1 * 0.02).all()
 
     # Rest for 15 minutes, so that all RC elements and temperature equilibrate
     pre_inputs = new_inputs
-    new_inputs = TheveninInput(current=0., time=pre_inputs.time + 15 * 60., t_inf=298.)
+    new_inputs = TheveninInput(current=0., time=pre_inputs.time + 15 * 60., t_inf=25.)
     state = model.update_transient_state(pre_inputs, new_inputs, state, asoh)
     assert np.allclose(state.soc, 1.)
     assert np.allclose(state.eta, 0.)
-    assert np.isclose(state.temp, 298.)
+    assert np.isclose(state.cell_temperature, 25.)
 
     v = model.calculate_terminal_voltage(new_inputs, state, asoh)
     assert np.isclose(v.terminal_voltage, 2.5).all()
 
     # Discharge for an hour to get back to SOC 0
     pre_inputs = new_inputs
-    new_inputs = TheveninInput(current=-1, time=pre_inputs.time + 3600., t_inf=298.)
+    new_inputs = TheveninInput(current=-1, time=pre_inputs.time + 3600., t_inf=25.)
     state = model.update_transient_state(pre_inputs, new_inputs, state, asoh)
     assert np.allclose(state.soc, 0.)
     assert np.greater(state.eta, 0.).all()
-    assert np.greater(state.temp, 298.).all()
+    assert np.greater(state.cell_temperature, 25.).all()
 
     v = model.calculate_terminal_voltage(new_inputs, state, asoh)
     assert np.less_equal(v.terminal_voltage, 1.5 - 1 * 0.01).all()
 
     # Rest for 15 minutes, so that all RC elements and temperature equilibrate
     pre_inputs = new_inputs
-    new_inputs = TheveninInput(current=0., time=pre_inputs.time + 15 * 60., t_inf=298.)
+    new_inputs = TheveninInput(current=0., time=pre_inputs.time + 15 * 60., t_inf=25.)
     state = model.update_transient_state(pre_inputs, new_inputs, state, asoh)
     assert np.allclose(state.soc, 0.)
     assert np.allclose(state.eta, 0.)
-    assert np.isclose(state.temp, 298.)
+    assert np.isclose(state.cell_temperature, 25.)
 
     v = model.calculate_terminal_voltage(new_inputs, state, asoh)
     assert np.isclose(v.terminal_voltage, 1.5).all()
@@ -127,13 +127,13 @@ def test_batching():
 
     # The temperature of the cell should be higher with higher resistance
     state = TheveninTransient.from_asoh(asoh)
-    pre_inputs = TheveninInput(current=1., time=0., t_inf=298.)
-    new_inputs = TheveninInput(current=1., time=30., t_inf=298.)
+    pre_inputs = TheveninInput(current=1., time=0., t_inf=25.)
+    new_inputs = TheveninInput(current=1., time=30., t_inf=25.)
 
     new_state = model.update_transient_state(pre_inputs, new_inputs, state, asoh)
     assert new_state.batch_size == 3
-    assert (np.diff(new_state.temp[:, 0]) > 0).all()  # Temperatures should be increasing
-    assert np.std(new_state.soc) == 0.  # SOC should all be the same
+    assert (np.diff(new_state.cell_temperature[:, 0]) > 0).all()  # Temperatures should be increasing
+    assert np.std(new_state.soc) < 1e-6  # SOC should all be the same
 
     # Compute the voltage
     soc = 1. / 120
@@ -148,8 +148,8 @@ def test_estimator():
     # Test a single step at constant current
     asoh = rint.model_copy(deep=True)
     state = TheveninTransient.from_asoh(asoh)
-    pre_inputs = TheveninInput(current=1., time=0., t_inf=298.)
-    new_inputs = TheveninInput(current=1., time=30., t_inf=298.)
+    pre_inputs = TheveninInput(current=1., time=0., t_inf=25.)
+    new_inputs = TheveninInput(current=1., time=30., t_inf=25.)
 
     model = TheveninModel(isothermal=True)
 
@@ -171,7 +171,7 @@ def test_estimator():
 
     # Write down the expected results after 30 seconds of a 1A charge
     soc = 1. / 120
-    expected_state = [soc, 298, 0]
+    expected_state = [soc, 25., 0]
     expected_v = 1.5 + soc + 1 * (0.01 * (1 + soc))
 
     est_state, est_outputs = est.step(new_inputs, OutputQuantities(terminal_voltage=expected_v))
@@ -239,8 +239,8 @@ def test_overpotentials():
 
     # Charge for 10s at 1A
     state = TheveninTransient.from_asoh(rc)
-    pre_inputs = TheveninInput(current=1., time=0., t_inf=298.)
-    new_inputs = TheveninInput(current=1., time=10., t_inf=298.)
+    pre_inputs = TheveninInput(current=1., time=0., t_inf=25.)
+    new_inputs = TheveninInput(current=1., time=10., t_inf=25.)
 
     model = TheveninModel()
     new_state = model.update_transient_state(pre_inputs, new_inputs, state, rc)


### PR DESCRIPTION
First is an easy change: We were using K in thevenin and C in the other ECM. We don't need absolute zero in our physics so far, so am opting for C in Thevenin

Second is a bit of a patch job: Until we figure out how to address temperature as a state or output (#114 , #156 ), I'm making it so that we use it as an input for isothermal models and propagate cell temperature without adjustment for ones where we use temperature. It happens that I'm only using isothermal Thevenin for now anyway.