### PR TITLE
Remove CellDataset from moirae

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,18 +16,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: actions/setup-python@v3
         with:
-            environment-file: dev/environment.yml
-            activate-environment: test
-            auto-activate-base: true
-            auto-update-conda: false
-            remove-profiles: true
-            architecture: x64
-            clean-patched-environment-file: true
-            run-post: true
-            use-mamba: false
-            miniforge-version: latest
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          pip install -e .[test,docs,thevenin]
       - name: Lint with flake8
         run: |
           flake8 moirae/ tests

--- a/dev/environment.yml
+++ b/dev/environment.yml
@@ -10,7 +10,6 @@ dependencies:
     # Basics
     - tqdm
     - matplotlib
-    - pytables
 
     - jupyterlab
     - -e ..[test,docs,thevenin]

--- a/dev/environment.yml
+++ b/dev/environment.yml
@@ -5,16 +5,12 @@ channels:
 dependencies:
   - python==3.10.*
 
-  # Basics
-  - tqdm
-  - matplotlib
-  - pytables
-
-  # Thevenin
-  - scikits_odes_sundials
-
   - pip
   - pip:
-    - battery-data-toolkit
+    # Basics
+    - tqdm
+    - matplotlib
+    - pytables
+
     - jupyterlab
     - -e ..[test,docs,thevenin]

--- a/docs/extractors/demonstrate-ecm-extractors.ipynb
+++ b/docs/extractors/demonstrate-ecm-extractors.ipynb
@@ -18,7 +18,7 @@
    "source": [
     "%matplotlib inline\n",
     "from matplotlib import pyplot as plt\n",
-    "from battdat.data import BatteryDataset, CellDataset\n",
+    "from battdat.data import BatteryDataset\n",
     "import numpy as np"
    ]
   },
@@ -290,7 +290,7 @@
     }
    ],
    "source": [
-    "data.tables['raw_data']"
+    "data.raw_data"
    ]
   },
   {
@@ -401,7 +401,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.FillBetweenPolyCollection at 0x7177b1112f80>"
+       "<matplotlib.collections.FillBetweenPolyCollection at 0x74e1204de890>"
       ]
      },
      "execution_count": 7,
@@ -526,7 +526,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x7177b1030580>"
+       "<matplotlib.legend.Legend at 0x74e1203dae60>"
       ]
      },
      "execution_count": 11,
@@ -663,7 +663,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x7177b0e249d0>"
+       "<matplotlib.legend.Legend at 0x74e1201ec4c0>"
       ]
      },
      "execution_count": 15,
@@ -720,7 +720,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data = CellDataset.from_hdf('files/hppc_1rc.h5')\n",
+    "data = BatteryDataset.from_hdf('files/hppc_1rc.h5')\n",
     "data.tables['raw_data']['state'] = data.tables['raw_data']['state'].str.decode('utf-8')"
    ]
   },

--- a/docs/tutorials/ecm-to-online-estimation.ipynb
+++ b/docs/tutorials/ecm-to-online-estimation.ipynb
@@ -69,8 +69,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from battdat.data import CellDataset\n",
-    "data = CellDataset.from_hdf(data_path)"
+    "from battdat.data import BatteryDataset\n",
+    "data = BatteryDataset.from_hdf(data_path)"
    ]
   },
   {

--- a/moirae/simulator.py
+++ b/moirae/simulator.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 from typing import Tuple, List, Optional
 
-from battdat.data import BatteryDataset, CellDataset
+from battdat.data import BatteryDataset
 from battdat.schemas.column import ColumnInfo, DataType
 from moirae.models.base import (HealthVariable,
                                 GeneralContainer,
@@ -190,7 +190,7 @@ class Simulator:
 
         output = []
         for _, group in df.groupby('batch'):
-            batch = CellDataset(raw_data=group.drop(columns=['batch']))
+            batch = BatteryDataset.make_cell_dataset(raw_data=group.drop(columns=['batch']))
 
             # Compile names for the other columns
             #  TODO (wardlt): I bet I can grab the description from the model fields.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from typing import Tuple
 
 from pytest import fixture
-from battdat.data import BatteryDataset, CellDataset
+from battdat.data import BatteryDataset
 import pandas as pd
 import numpy as np
 
@@ -88,7 +88,7 @@ def make_dataset(simple_rint):
         battery=BatteryDescription(nominal_capacity=rint_asoh.q_t.amp_hour.item())
     )
 
-    return CellDataset(raw_data=raw_data, metadata=metadata)
+    return BatteryDataset.make_cell_dataset(raw_data=raw_data, metadata=metadata)
 
 
 @fixture()
@@ -203,12 +203,7 @@ def make_dataset_hppc(model_and_params):
     metadata = BatteryMetadata(
         battery=BatteryDescription(nominal_capacity=asoh.q_t.amp_hour.item())
     )
-
-    # CellDataset(
-    #     raw_data=raw_data, metadata=metadata).to_hdf(
-    #         '../../docs/extractors/files/hppc_1rc.h5', complevel=9)
-
-    return CellDataset(raw_data=raw_data, metadata=metadata)
+    return BatteryDataset.make_cell_dataset(raw_data=raw_data, metadata=metadata)
 
 
 @fixture()


### PR DESCRIPTION
We've removed specialized dataset subclasses from battdat: https://github.com/ROVI-org/battery-data-toolkit/pull/135

``BatteryDataset`` now behaves like ``CellDataset`` (e.g., `data.cycle_stats` retrieves the "cycle_stats" table), but you build a dataset with pre-defined schema differently

I also moved us from conda to PyPI for building the environment, given that we no longer need conda-provided packages and I was getting intermittent build failures with conda