### PR TITLE
Installs battdat from git

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
     {name = "Noah Paulson", email = "npaulson@anl.gov"},
 ]
 dependencies = [
-    "battery-data-toolkit",
+    "battery-data-toolkit@git+https://github.com/ROVI-org/battery-data-toolkit",
     "pydantic",
     "numpy",
     "scipy",


### PR DESCRIPTION
This way, if we have new developments on the battery-data-toolkit that have not yet been published to PyPI, we can continue successfully using moirae.