### PR TITLE
Quick capacity extraction fix

### DIFF
--- a/moirae/extractors/ecm/capacity.py
+++ b/moirae/extractors/ecm/capacity.py
@@ -22,7 +22,7 @@ class MaxCapacityExtractor(BaseExtractor):
     def extract(self, data: BatteryDataset) -> MaxTheoreticalCapacity:
         # Access or compute cycle-level capacity
         cycle_stats = data.tables.get('cycle_stats')
-        if cycle_stats is None or 'capacity_charge' not in cycle_stats:
+        if cycle_stats is None or 'max_cycled_capacity' not in cycle_stats:
             cycle_stats = CapacityPerCycle().compute_features(data)
 
         max_q = cycle_stats['max_cycled_capacity'].max()

--- a/moirae/extractors/ecm/capacity.py
+++ b/moirae/extractors/ecm/capacity.py
@@ -25,5 +25,5 @@ class MaxCapacityExtractor(BaseExtractor):
         if cycle_stats is None or 'capacity_charge' not in cycle_stats:
             cycle_stats = CapacityPerCycle().compute_features(data)
 
-        max_q = cycle_stats['capacity_charge'].max()
+        max_q = cycle_stats['max_cycled_capacity'].max()
         return MaxTheoreticalCapacity(base_values=max_q)


### PR DESCRIPTION
Fixes issue with capacity extraction. New additions to the toolkit allow us to compute the maximum amount of charge that has been cycled on the given cycle, bypassing assumptions related to starting/end SOC, as well as to what happens first during the cycle. We incorporate those here. 

Fixes #173 